### PR TITLE
Add Perchance Interpreter as Lua Dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,6 +1351,7 @@ dependencies = [
  "flume",
  "mlua",
  "perchance-interpreter",
+ "rand 0.8.5",
  "serde",
  "serenity",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
  "async-openai",
  "flume",
  "mlua",
+ "perchance-interpreter",
  "serde",
  "serenity",
  "tokio",
@@ -1361,6 +1362,14 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "perchance-interpreter"
+version = "0.1.0"
+source = "git+https://github.com/philpax/perchance-interpreter#71817d7ef09a97ab47ba69d3f22e262faa74bffa"
+dependencies = [
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "pin-project"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,7 +1367,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 [[package]]
 name = "perchance-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/philpax/perchance-interpreter#71817d7ef09a97ab47ba69d3f22e262faa74bffa"
+source = "git+https://github.com/philpax/perchance-interpreter#3fa001454f96c5998ed704ccbdd6017f8d511d8e"
 dependencies = [
  "rand 0.8.5",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ mlua = { version = "=0.11.0-beta.1", features = [
     "send",
     "error-send",
 ] }
+perchance-interpreter = { git = "https://github.com/philpax/perchance-interpreter" }
+rand = "0.8"
 serde = { version = "1.0.150", features = ["derive"] }
 serenity = { version = "0.12.4" }
 tokio = { version = "1.0", features = ["full"] }

--- a/src/commands/execute/extensions/mod.rs
+++ b/src/commands/execute/extensions/mod.rs
@@ -4,6 +4,7 @@ use crate::ai::Ai;
 
 mod globals;
 mod llm;
+mod perchance;
 
 pub fn register(
     lua: &mlua::Lua,
@@ -13,5 +14,6 @@ pub fn register(
 ) -> mlua::Result<()> {
     globals::register(lua, output_tx, print_tx)?;
     llm::register(lua, ai)?;
+    perchance::register(lua)?;
     Ok(())
 }

--- a/src/commands/execute/extensions/perchance.rs
+++ b/src/commands/execute/extensions/perchance.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use perchance_interpreter::CompiledProgram;
+
+pub fn register(lua: &mlua::Lua) -> mlua::Result<()> {
+    let perchance = lua.create_table()?;
+
+    // Simple one-shot evaluation
+    perchance.set(
+        "evaluate",
+        lua.create_function(|_lua, (template, seed): (String, u64)| {
+            perchance_interpreter::evaluate_with_seed(&template, seed)
+                .map_err(|e| mlua::Error::ExternalError(Arc::new(e)))
+        })?,
+    )?;
+
+    // Compile a template for reuse
+    perchance.set(
+        "compile",
+        lua.create_function(|lua, template: String| {
+            let compiled = perchance_interpreter::compile_template(&template)
+                .map_err(|e| mlua::Error::ExternalError(Arc::new(e)))?;
+            lua.create_any_userdata(compiled)
+        })?,
+    )?;
+
+    lua.globals().set("perchance", perchance)?;
+
+    Ok(())
+}
+
+impl mlua::UserData for CompiledProgram {
+    fn add_methods<M: mlua::UserDataMethods<Self>>(methods: &mut M) {
+        methods.add_method("evaluate", |_lua, this, seed: u64| {
+            use rand::SeedableRng;
+            let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+            perchance_interpreter::evaluate(this, &mut rng)
+                .map_err(|e| mlua::Error::ExternalError(Arc::new(e)))
+        });
+    }
+}


### PR DESCRIPTION
Add perchance-interpreter as a dependency and expose its functionality to the Lua interface with two APIs:

- perchance.evaluate(template, seed): One-shot evaluation for quick use
- perchance.compile(template): Compile a template once, then call :evaluate(seed) multiple times for efficient reuse

This allows Lua scripts to leverage Perchance templates for procedural text generation with deterministic randomization.