### PR TITLE
feat: add reply handler for interaction responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +596,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +843,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "http"
@@ -1275,6 +1292,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "lua-src"
 version = "548.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,6 +1575,7 @@ dependencies = [
  "anyhow",
  "async-openai",
  "flume",
+ "lru",
  "mlua",
  "perchance-interpreter",
  "rand 0.8.5",
@@ -3142,7 +3169,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ serde_json = "1.0"
 serenity = { version = "0.12.4" }
 tokio = { version = "1.0", features = ["full"] }
 toml = "0.7.3"
+lru = "0.12"

--- a/scripts/commands.lua
+++ b/scripts/commands.lua
@@ -521,7 +521,15 @@ discord.register_command {
 -- Reply handler for /ask - continues the conversation
 discord.register_reply_handler("ask", function(chain)
 	local model = chain.options.model
-	local original_seed = chain.options.seed or math.random(1, 2147483647)
+	local original_seed = chain.options.seed
+
+	-- Require original parameters
+	if not model then
+		error("Original model parameter not available - cannot continue conversation")
+	end
+	if not original_seed then
+		error("Original seed parameter not available - cannot continue conversation")
+	end
 
 	output("Continuing conversation...")
 
@@ -555,8 +563,12 @@ end)
 
 -- Reply handler for /paint - regenerates image with new prompt
 discord.register_reply_handler("paint", function(chain)
-	-- Get the original options
+	-- Get the original options - require model
 	local original_model = chain.options.model
+	if not original_model then
+		error("Original model parameter not available - cannot regenerate image")
+	end
+
 	local original_width = chain.options.width
 	local original_height = chain.options.height
 	local original_negative = chain.options.negative or "text, watermark, blurry"
@@ -578,8 +590,8 @@ discord.register_reply_handler("paint", function(chain)
 	-- Generate a new seed for variation
 	local new_seed = math.random(1, 2147483647)
 
-	-- Use the original model or get a random one
-	local model_info = original_model and get_model_info(original_model) or get_random_model()
+	-- Get model info from the original model
+	local model_info = get_model_info(original_model)
 
 	-- Generate the image with the new prompt
 	generate_image(new_prompt, original_negative, new_seed, model_info, original_width, original_height)

--- a/src/commands/execute.rs
+++ b/src/commands/execute.rs
@@ -158,7 +158,9 @@ impl SharedState {
             },
             Some(self.cancel_rx.clone()),
         )
-        .await
+        .await?;
+
+        Ok(())
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,8 @@ pub struct Discord {
     pub message_update_interval_ms: u64,
     /// Whether or not to replace '\n' with newlines
     pub replace_newlines: bool,
+    /// Size of the LRU cache for interaction contexts (for reply handling)
+    pub interaction_context_cache_size: usize,
 }
 
 impl Default for Discord {
@@ -61,6 +63,7 @@ impl Default for Discord {
         Self {
             message_update_interval_ms: 1000,
             replace_newlines: true,
+            interaction_context_cache_size: 10000,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,23 +1,11 @@
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(default)]
 pub struct Configuration {
     pub authentication: Authentication,
     pub discord: Discord,
-}
-impl Default for Configuration {
-    fn default() -> Self {
-        Self {
-            authentication: Authentication {
-                discord_token: None,
-                openai_api_server: None,
-                openai_api_key: None,
-            },
-            discord: Discord::default(),
-        }
-    }
 }
 impl Configuration {
     const FILENAME: &str = "config.toml";
@@ -41,7 +29,8 @@ impl Configuration {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(default)]
 pub struct Authentication {
     pub discord_token: Option<String>,
     pub openai_api_server: Option<String>,
@@ -49,6 +38,7 @@ pub struct Authentication {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub struct Discord {
     /// Low values will result in you getting throttled by Discord
     pub message_update_interval_ms: u64,

--- a/src/interaction_context.rs
+++ b/src/interaction_context.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, num::NonZeroUsize, sync::Mutex};
 
 use lru::LruCache;
+use serde::Serialize;
 use serenity::all::{ChannelId, GuildId, MessageId, UserId};
 
 /// Context stored for an interaction response, allowing us to handle replies
@@ -22,7 +23,8 @@ pub struct InteractionContext {
 }
 
 /// A command option value
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
+#[serde(untagged)]
 pub enum OptionValue {
     String(String),
     Integer(i64),

--- a/src/interaction_context.rs
+++ b/src/interaction_context.rs
@@ -1,0 +1,96 @@
+use std::{collections::HashMap, num::NonZeroUsize, sync::Mutex};
+
+use lru::LruCache;
+use serenity::all::{ChannelId, GuildId, MessageId, UserId};
+
+/// Context stored for an interaction response, allowing us to handle replies
+#[derive(Clone, Debug)]
+pub struct InteractionContext {
+    /// The command that was invoked
+    pub command_name: String,
+    /// The options passed to the command (name -> value as string/number)
+    pub options: HashMap<String, OptionValue>,
+    /// The user who invoked the command
+    #[allow(dead_code)]
+    pub user_id: UserId,
+    /// The channel where the command was invoked
+    #[allow(dead_code)]
+    pub channel_id: ChannelId,
+    /// The guild where the command was invoked (None for DMs)
+    #[allow(dead_code)]
+    pub guild_id: Option<GuildId>,
+}
+
+/// A command option value
+#[derive(Clone, Debug)]
+pub enum OptionValue {
+    String(String),
+    Integer(i64),
+    Number(f64),
+    Boolean(bool),
+}
+
+#[allow(dead_code)]
+impl OptionValue {
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            OptionValue::String(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            OptionValue::Integer(i) => Some(*i),
+            _ => None,
+        }
+    }
+
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            OptionValue::Number(n) => Some(*n),
+            OptionValue::Integer(i) => Some(*i as f64),
+            _ => None,
+        }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            OptionValue::Boolean(b) => Some(*b),
+            _ => None,
+        }
+    }
+}
+
+/// Thread-safe LRU cache for interaction contexts
+pub struct InteractionContextStore {
+    cache: Mutex<LruCache<MessageId, InteractionContext>>,
+}
+
+impl InteractionContextStore {
+    /// Create a new store with the given capacity
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            cache: Mutex::new(LruCache::new(
+                NonZeroUsize::new(capacity).expect("capacity must be non-zero"),
+            )),
+        }
+    }
+
+    /// Store context for a message ID (the bot's response message)
+    pub fn store(&self, message_id: MessageId, context: InteractionContext) {
+        self.cache.lock().unwrap().put(message_id, context);
+    }
+
+    /// Get context for a message ID
+    pub fn get(&self, message_id: &MessageId) -> Option<InteractionContext> {
+        self.cache.lock().unwrap().get(message_id).cloned()
+    }
+}
+
+impl Default for InteractionContextStore {
+    fn default() -> Self {
+        // Default to 1000 entries - should be plenty for most use cases
+        Self::new(1000)
+    }
+}

--- a/src/interaction_context.rs
+++ b/src/interaction_context.rs
@@ -87,10 +87,3 @@ impl InteractionContextStore {
         self.cache.lock().unwrap().get(message_id).cloned()
     }
 }
-
-impl Default for InteractionContextStore {
-    fn default() -> Self {
-        // Default to 1000 entries - should be plenty for most use cases
-        Self::new(1000)
-    }
-}

--- a/src/lua/discord_extension.rs
+++ b/src/lua/discord_extension.rs
@@ -1,12 +1,24 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
 use mlua::prelude::*;
 use serenity::all::CommandOptionType;
 
 use crate::commands::lua_command::{LuaCommand, LuaCommandOption, LuaCommandRegistry};
 
-pub fn register(lua: &Lua, registry: LuaCommandRegistry) -> LuaResult<()> {
+/// Registry for reply handlers (command name -> Lua handler function)
+pub type LuaReplyHandlerRegistry = Arc<Mutex<HashMap<String, LuaFunction>>>;
+
+pub fn register(
+    lua: &Lua,
+    command_registry: LuaCommandRegistry,
+    reply_handler_registry: LuaReplyHandlerRegistry,
+) -> LuaResult<()> {
     let discord = lua.create_table()?;
 
-    let registry_clone = registry.clone();
+    let registry_clone = command_registry.clone();
     let register_command = lua.create_function(move |_lua, spec: LuaTable| {
         let name: String = spec.get("name")?;
         let description: String = spec.get("description")?;
@@ -34,7 +46,18 @@ pub fn register(lua: &Lua, registry: LuaCommandRegistry) -> LuaResult<()> {
         Ok(())
     })?;
 
+    let reply_registry_clone = reply_handler_registry.clone();
+    let register_reply_handler =
+        lua.create_function(move |_lua, (command_name, handler): (String, LuaFunction)| {
+            reply_registry_clone
+                .lock()
+                .unwrap()
+                .insert(command_name, handler);
+            Ok(())
+        })?;
+
     discord.set("register_command", register_command)?;
+    discord.set("register_reply_handler", register_reply_handler)?;
     lua.globals().set("discord", discord)?;
 
     Ok(())

--- a/src/lua/discord_extension.rs
+++ b/src/lua/discord_extension.rs
@@ -47,14 +47,15 @@ pub fn register(
     })?;
 
     let reply_registry_clone = reply_handler_registry.clone();
-    let register_reply_handler =
-        lua.create_function(move |_lua, (command_name, handler): (String, LuaFunction)| {
+    let register_reply_handler = lua.create_function(
+        move |_lua, (command_name, handler): (String, LuaFunction)| {
             reply_registry_clone
                 .lock()
                 .unwrap()
                 .insert(command_name, handler);
             Ok(())
-        })?;
+        },
+    )?;
 
     discord.set("register_command", register_command)?;
     discord.set("register_reply_handler", register_reply_handler)?;

--- a/src/lua/executor.rs
+++ b/src/lua/executor.rs
@@ -43,6 +43,7 @@ pub async fn execute_lua_reply_thread(
     discord_config: &config::Discord,
     thread: mlua::AsyncThread<Option<String>>,
     channels: LuaOutputChannels,
+    cancel_rx: Option<flume::Receiver<MessageId>>,
 ) -> anyhow::Result<MessageId> {
     let outputter = OutputterHandle::new_reply(
         http,
@@ -53,7 +54,7 @@ pub async fn execute_lua_reply_thread(
     )
     .await?;
 
-    execute_lua_thread_impl(outputter, thread, channels, None).await
+    execute_lua_thread_impl(outputter, thread, channels, cancel_rx).await
 }
 
 /// Common implementation for executing Lua threads with output handling

--- a/src/lua/executor.rs
+++ b/src/lua/executor.rs
@@ -20,9 +20,9 @@ pub async fn execute_lua_thread(
     http: Arc<Http>,
     cmd: &CommandInteraction,
     discord_config: &config::Discord,
-    mut thread: mlua::AsyncThread<Option<String>>,
+    thread: mlua::AsyncThread<Option<String>>,
     channels: LuaOutputChannels,
-    mut cancel_rx: Option<flume::Receiver<MessageId>>,
+    cancel_rx: Option<flume::Receiver<MessageId>>,
 ) -> anyhow::Result<MessageId> {
     let outputter = OutputterHandle::new(
         http,
@@ -32,6 +32,37 @@ pub async fn execute_lua_thread(
     )
     .await?;
 
+    execute_lua_thread_impl(outputter, thread, channels, cancel_rx).await
+}
+
+/// Executes a Lua async thread in response to a message reply
+pub async fn execute_lua_reply_thread(
+    http: Arc<Http>,
+    reply_to: &Message,
+    user_id: UserId,
+    discord_config: &config::Discord,
+    thread: mlua::AsyncThread<Option<String>>,
+    channels: LuaOutputChannels,
+) -> anyhow::Result<MessageId> {
+    let outputter = OutputterHandle::new_reply(
+        http,
+        reply_to,
+        user_id,
+        discord_config.message_update_interval_ms,
+        "Processing reply...",
+    )
+    .await?;
+
+    execute_lua_thread_impl(outputter, thread, channels, None).await
+}
+
+/// Common implementation for executing Lua threads with output handling
+async fn execute_lua_thread_impl(
+    outputter: OutputterHandle,
+    mut thread: mlua::AsyncThread<Option<String>>,
+    channels: LuaOutputChannels,
+    mut cancel_rx: Option<flume::Receiver<MessageId>>,
+) -> anyhow::Result<MessageId> {
     struct Output {
         output: String,
         print_log: Vec<String>,
@@ -140,113 +171,4 @@ async fn next_if_some<T>(rx: &mut Option<flume::Receiver<T>>) -> Option<T> {
         Some(receiver) => receiver.stream().next().await,
         None => std::future::pending().await,
     }
-}
-
-/// Executes a Lua async thread in response to a message reply
-pub async fn execute_lua_reply_thread(
-    http: Arc<Http>,
-    reply_to: &Message,
-    user_id: UserId,
-    discord_config: &config::Discord,
-    mut thread: mlua::AsyncThread<Option<String>>,
-    channels: LuaOutputChannels,
-) -> anyhow::Result<MessageId> {
-    let outputter = OutputterHandle::new_reply(
-        http,
-        reply_to,
-        user_id,
-        discord_config.message_update_interval_ms,
-        "Processing reply...",
-    )
-    .await?;
-
-    struct Output {
-        output: String,
-        print_log: Vec<String>,
-    }
-    impl Output {
-        pub fn to_final_output(&self) -> String {
-            let mut output = self.output.clone();
-            if !self.print_log.is_empty() {
-                output.push_str("\n**Print Log**\n");
-                for print in self.print_log.iter() {
-                    output.push_str(print);
-                    output.push('\n');
-                }
-            }
-            output
-        }
-    }
-    let mut output = Output {
-        output: String::new(),
-        print_log: vec![],
-    };
-
-    let mut errored = false;
-    let mut thread_result: Option<String> = None;
-    let mut output_stream = channels.output_rx.stream();
-    let mut print_stream = channels.print_rx.stream();
-    let mut attachment_stream = channels.attachment_rx.stream();
-
-    let starting_message_id = outputter.starting_message_id();
-
-    loop {
-        tokio::select! {
-            biased;
-
-            // Handle values from output stream
-            Some(value) = output_stream.next() => {
-                output.output = value;
-                outputter.update(&output.to_final_output());
-            }
-
-            // Handle values from print stream
-            Some(value) = print_stream.next() => {
-                output.print_log.push(value);
-                outputter.update(&output.to_final_output());
-            }
-
-            // Handle attachments
-            Some(attachment) = attachment_stream.next() => {
-                outputter.add_attachment(attachment);
-            }
-
-            // Handle thread stream
-            thread_next = thread.next() => {
-                match thread_next {
-                    Some(Ok(result)) => {
-                        // Capture the return value from the thread
-                        if let Some(value) = result {
-                            thread_result = Some(value);
-                        }
-                        outputter.update(&output.to_final_output());
-                    }
-                    Some(Err(err)) => {
-                        outputter.error(&err.to_string());
-                        errored = true;
-                        break;
-                    }
-                    None => {
-                        // Thread stream exhausted
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    if !errored {
-        // If no explicit output was set but the thread returned a value, use that as output
-        if output.output.is_empty()
-            && let Some(result) = thread_result
-        {
-            output.output = result;
-            outputter.update(&output.to_final_output());
-        }
-        outputter.finish();
-    }
-
-    outputter.join().await?;
-
-    Ok(starting_message_id)
 }

--- a/src/lua/executor.rs
+++ b/src/lua/executor.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use serenity::{
-    all::{CommandInteraction, Http, MessageId},
+    all::{CommandInteraction, Http, Message, MessageId, UserId},
     futures::StreamExt as _,
 };
 
@@ -15,6 +15,7 @@ pub struct LuaOutputChannels {
 }
 
 /// Executes a Lua async thread with output handling and optional cancellation support.
+/// Returns the message ID of the bot's response.
 pub async fn execute_lua_thread(
     http: Arc<Http>,
     cmd: &CommandInteraction,
@@ -22,7 +23,7 @@ pub async fn execute_lua_thread(
     mut thread: mlua::AsyncThread<Option<String>>,
     channels: LuaOutputChannels,
     mut cancel_rx: Option<flume::Receiver<MessageId>>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<MessageId> {
     let outputter = OutputterHandle::new(
         http,
         cmd,
@@ -129,7 +130,7 @@ pub async fn execute_lua_thread(
 
     outputter.join().await?;
 
-    Ok(())
+    Ok(starting_message_id)
 }
 
 /// Helper to get next item from an optional receiver by creating a temporary stream.
@@ -139,4 +140,113 @@ async fn next_if_some<T>(rx: &mut Option<flume::Receiver<T>>) -> Option<T> {
         Some(receiver) => receiver.stream().next().await,
         None => std::future::pending().await,
     }
+}
+
+/// Executes a Lua async thread in response to a message reply
+pub async fn execute_lua_reply_thread(
+    http: Arc<Http>,
+    reply_to: &Message,
+    user_id: UserId,
+    discord_config: &config::Discord,
+    mut thread: mlua::AsyncThread<Option<String>>,
+    channels: LuaOutputChannels,
+) -> anyhow::Result<MessageId> {
+    let outputter = OutputterHandle::new_reply(
+        http,
+        reply_to,
+        user_id,
+        discord_config.message_update_interval_ms,
+        "Processing reply...",
+    )
+    .await?;
+
+    struct Output {
+        output: String,
+        print_log: Vec<String>,
+    }
+    impl Output {
+        pub fn to_final_output(&self) -> String {
+            let mut output = self.output.clone();
+            if !self.print_log.is_empty() {
+                output.push_str("\n**Print Log**\n");
+                for print in self.print_log.iter() {
+                    output.push_str(print);
+                    output.push('\n');
+                }
+            }
+            output
+        }
+    }
+    let mut output = Output {
+        output: String::new(),
+        print_log: vec![],
+    };
+
+    let mut errored = false;
+    let mut thread_result: Option<String> = None;
+    let mut output_stream = channels.output_rx.stream();
+    let mut print_stream = channels.print_rx.stream();
+    let mut attachment_stream = channels.attachment_rx.stream();
+
+    let starting_message_id = outputter.starting_message_id();
+
+    loop {
+        tokio::select! {
+            biased;
+
+            // Handle values from output stream
+            Some(value) = output_stream.next() => {
+                output.output = value;
+                outputter.update(&output.to_final_output());
+            }
+
+            // Handle values from print stream
+            Some(value) = print_stream.next() => {
+                output.print_log.push(value);
+                outputter.update(&output.to_final_output());
+            }
+
+            // Handle attachments
+            Some(attachment) = attachment_stream.next() => {
+                outputter.add_attachment(attachment);
+            }
+
+            // Handle thread stream
+            thread_next = thread.next() => {
+                match thread_next {
+                    Some(Ok(result)) => {
+                        // Capture the return value from the thread
+                        if let Some(value) = result {
+                            thread_result = Some(value);
+                        }
+                        outputter.update(&output.to_final_output());
+                    }
+                    Some(Err(err)) => {
+                        outputter.error(&err.to_string());
+                        errored = true;
+                        break;
+                    }
+                    None => {
+                        // Thread stream exhausted
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    if !errored {
+        // If no explicit output was set but the thread returned a value, use that as output
+        if output.output.is_empty()
+            && let Some(result) = thread_result
+        {
+            output.output = result;
+            outputter.update(&output.to_final_output());
+        }
+        outputter.finish();
+    }
+
+    outputter.join().await?;
+
+    Ok(starting_message_id)
 }

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -3,9 +3,10 @@ use std::sync::Arc;
 use crate::{ai::Ai, commands::lua_command::LuaCommandRegistry, currency::CurrencyConverter};
 
 mod discord_extension;
+pub use discord_extension::LuaReplyHandlerRegistry;
 
 mod executor;
-pub use executor::{LuaOutputChannels, execute_lua_thread};
+pub use executor::{LuaOutputChannels, execute_lua_reply_thread, execute_lua_thread};
 
 pub mod extensions;
 
@@ -44,10 +45,11 @@ pub fn create_global_lua_state(
     print_tx: flume::Sender<String>,
     attachment_tx: flume::Sender<extensions::Attachment>,
     lua_command_registry: LuaCommandRegistry,
+    lua_reply_handler_registry: LuaReplyHandlerRegistry,
 ) -> mlua::Result<mlua::Lua> {
     let lua =
         create_barebones_lua_state(ai, currency_converter, output_tx, print_tx, attachment_tx)?;
-    discord_extension::register(&lua, lua_command_registry)?;
+    discord_extension::register(&lua, lua_command_registry, lua_reply_handler_registry)?;
     load_lua_file(&lua, "scripts/commands.lua")?;
 
     Ok(lua)

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,9 @@ async fn main() -> anyhow::Result<()> {
     // Create command registry, reply handler registry, and interaction context store
     let command_registry = LuaCommandRegistry::default();
     let reply_handler_registry = LuaReplyHandlerRegistry::default();
-    let interaction_context_store = Arc::new(InteractionContextStore::default());
+    let interaction_context_store = Arc::new(InteractionContextStore::new(
+        config.discord.interaction_context_cache_size,
+    ));
 
     // We intentionally do not use _output_rx/_attachment_rx, as we don't care about temporary output at the global level
     let (output_tx, _output_rx) = flume::unbounded::<String>();

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,7 @@ async fn main() -> anyhow::Result<()> {
         config: config.clone(),
         handlers: Arc::new(std::sync::Mutex::new(handlers)),
         cancel_tx,
+        cancel_rx,
         interaction_context_store: interaction_context_store.clone(),
         reply_handler_registry: reply_handler_registry.clone(),
         global_lua: global_lua.clone(),
@@ -158,6 +159,7 @@ pub struct Handler {
     config: Configuration,
     handlers: Arc<std::sync::Mutex<HashMap<String, Arc<dyn commands::CommandHandler>>>>,
     cancel_tx: flume::Sender<MessageId>,
+    cancel_rx: flume::Receiver<MessageId>,
     interaction_context_store: Arc<InteractionContextStore>,
     reply_handler_registry: LuaReplyHandlerRegistry,
     global_lua: mlua::Lua,
@@ -388,6 +390,7 @@ impl Handler {
                 print_rx,
                 attachment_rx,
             },
+            Some(self.cancel_rx.clone()),
         )
         .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,9 @@ async fn main() -> anyhow::Result<()> {
 
     let mut client = Client::builder(
         discord_token,
-        GatewayIntents::default() | GatewayIntents::GUILD_MESSAGES | GatewayIntents::MESSAGE_CONTENT,
+        GatewayIntents::default()
+            | GatewayIntents::GUILD_MESSAGES
+            | GatewayIntents::MESSAGE_CONTENT,
     )
     .event_handler(Handler {
         config: config.clone(),
@@ -94,8 +96,8 @@ async fn main() -> anyhow::Result<()> {
         reply_handler_registry: reply_handler_registry.clone(),
         global_lua: global_lua.clone(),
     })
-        .await
-        .context("Error creating client")?;
+    .await
+    .context("Error creating client")?;
 
     if let Err(why) = client.start().await {
         println!("Client error: {why:?}");
@@ -189,15 +191,13 @@ impl EventHandler for Handler {
         }
 
         // Check if this is a reply to another message
-        if let Some(ref msg_ref) = msg.message_reference {
-            if let Some(referenced_msg_id) = msg_ref.message_id {
-                if let Err(err) = self
-                    .handle_reply(ctx.http.clone(), &msg, referenced_msg_id)
-                    .await
-                {
-                    eprintln!("Error handling reply: {err}");
-                }
-            }
+        if let Some(ref msg_ref) = msg.message_reference
+            && let Some(referenced_msg_id) = msg_ref.message_id
+            && let Err(err) = self
+                .handle_reply(ctx.http.clone(), &msg, referenced_msg_id)
+                .await
+        {
+            eprintln!("Error handling reply: {err}");
         }
     }
 }
@@ -255,8 +255,8 @@ impl Handler {
     ) -> anyhow::Result<()> {
         use crate::{
             interaction_context::OptionValue,
-            lua::{LuaOutputChannels, execute_lua_reply_thread},
             lua::extensions::{Attachment, TemporaryChannelUpdate},
+            lua::{LuaOutputChannels, execute_lua_reply_thread},
             reply_handler::{ReplyChain, build_message_chain},
         };
 
@@ -276,11 +276,11 @@ impl Handler {
                 // Find a bot message with cached context
                 let mut found_context = None;
                 for chain_msg in &chain {
-                    if chain_msg.is_bot {
-                        if let Some(ctx) = self.interaction_context_store.get(&chain_msg.id) {
-                            found_context = Some(ctx);
-                            break;
-                        }
+                    if chain_msg.is_bot
+                        && let Some(ctx) = self.interaction_context_store.get(&chain_msg.id)
+                    {
+                        found_context = Some(ctx);
+                        break;
                     }
                 }
 
@@ -390,7 +390,8 @@ impl Handler {
         .await?;
 
         // Store the context for the new response message so the chain can continue
-        self.interaction_context_store.store(response_msg_id, context);
+        self.interaction_context_store
+            .store(response_msg_id, context);
 
         Ok(())
     }

--- a/src/reply_handler.rs
+++ b/src/reply_handler.rs
@@ -1,0 +1,100 @@
+use std::collections::HashMap;
+
+use serenity::all::{ChannelId, GuildId, Http, Message, MessageId, UserId};
+
+use crate::interaction_context::OptionValue;
+
+/// A message in the conversation chain
+#[derive(Clone, Debug)]
+pub struct ChainMessage {
+    /// The message ID
+    pub id: MessageId,
+    /// The message content
+    pub content: String,
+    /// The author's user ID
+    pub author_id: UserId,
+    /// The author's username
+    pub author_name: String,
+    /// Whether this message is from the bot
+    pub is_bot: bool,
+    /// The channel ID
+    pub channel_id: ChannelId,
+    /// The guild ID (None for DMs)
+    pub guild_id: Option<GuildId>,
+    /// Attachments (URLs)
+    pub attachments: Vec<String>,
+}
+
+impl ChainMessage {
+    pub fn from_message(msg: &Message) -> Self {
+        Self {
+            id: msg.id,
+            content: msg.content.clone(),
+            author_id: msg.author.id,
+            author_name: msg.author.name.clone(),
+            is_bot: msg.author.bot,
+            channel_id: msg.channel_id,
+            guild_id: msg.guild_id,
+            attachments: msg.attachments.iter().map(|a| a.url.clone()).collect(),
+        }
+    }
+}
+
+/// The full context for a reply chain
+#[derive(Clone, Debug)]
+pub struct ReplyChain {
+    /// The original command that started this chain
+    pub command_name: String,
+    /// The original command options
+    pub options: HashMap<String, OptionValue>,
+    /// The message chain, from oldest to newest
+    /// First message is typically the bot's response to the original command
+    pub messages: Vec<ChainMessage>,
+}
+
+/// Build a message chain by walking up the reference chain
+pub async fn build_message_chain(
+    http: &Http,
+    starting_message: &Message,
+    max_depth: usize,
+) -> anyhow::Result<Vec<ChainMessage>> {
+    let mut chain = vec![ChainMessage::from_message(starting_message)];
+    let mut current_msg = starting_message.clone();
+
+    for _ in 0..max_depth {
+        // Check if this message references another
+        let Some(ref msg_ref) = current_msg.message_reference else {
+            break;
+        };
+
+        let Some(referenced_msg_id) = msg_ref.message_id else {
+            break;
+        };
+
+        // Try to use cached referenced_message first
+        if let Some(ref referenced) = current_msg.referenced_message {
+            chain.push(ChainMessage::from_message(referenced));
+            current_msg = (**referenced).clone();
+        } else {
+            // Fetch the message from Discord
+            match current_msg
+                .channel_id
+                .message(http, referenced_msg_id)
+                .await
+            {
+                Ok(fetched) => {
+                    chain.push(ChainMessage::from_message(&fetched));
+                    current_msg = fetched;
+                }
+                Err(_) => {
+                    // Can't fetch message, stop here
+                    break;
+                }
+            }
+        }
+    }
+
+    // Reverse so oldest is first
+    chain.reverse();
+    Ok(chain)
+}


### PR DESCRIPTION
Detects when users reply to bot messages that were responses to slash
commands and dispatches to registered Lua handlers with the full message
chain.

Changes:
- Add LRU cache (lru crate) for storing interaction context
- Store command name and options when slash commands are executed
- Add message_create event handler to detect replies
- Build message chain by walking up the reference chain
- Create new outputter variant for reply-based responses
- Add discord.register_reply_handler() Lua API
- Implement default handlers for /ask (conversation continuation) and
  /paint (image regeneration with new prompt)
- Enable GUILD_MESSAGES and MESSAGE_CONTENT gateway intents

The chain structure passed to Lua handlers includes:
- command_name: the original slash command
- options: the original command options
- messages: array of messages with id, content, author info, and
  attachments