### PR TITLE
Check if Lua accesses first message in chain

### DIFF
--- a/scripts/commands.lua
+++ b/scripts/commands.lua
@@ -645,6 +645,11 @@ discord.register_reply_handler("ask", function(chain)
 		llm.system(system),
 	}
 
+	-- Add the original prompt (slash command options aren't in chain.messages)
+	if chain.options.prompt then
+		table.insert(messages, llm.user(chain.options.prompt))
+	end
+
 	-- Add all messages from the chain
 	for _, msg in ipairs(chain.messages) do
 		if msg.is_bot then


### PR DESCRIPTION
The /ask reply handler was missing the original prompt when building the conversation history. Slash command invocations aren't Discord messages, so chain.messages starts with the bot's response, not the user's prompt. Now explicitly adds chain.options.prompt as the first user message.